### PR TITLE
Fix/cft 3464 update or remove soon deprecated minor version

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'feature/*'
       - 'bug/*'
+      - 'fix/*'
     tags:
       - '*' # Skip the workflow on the main branch without tags
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV PYTHONIOENCODING utf-8
 COPY . /code/
 
 # install gcc to be able to build packages - e.g. required by regex, dateparser, also required for pandas
-RUN apt-get update && apt-get install -y build-essential
+RUN apt-get update
 
 RUN pip install --upgrade pip
 

--- a/src/client.py
+++ b/src/client.py
@@ -162,7 +162,7 @@ class QuickbooksClient:
         # add minorversion to params
         if not params:
             params = {}
-        params["minorversion"] = 70
+        params["minorversion"] = 75
 
         results = None
         request_success = False


### PR DESCRIPTION
Ticket: https://keboola.atlassian.net/browse/SUPPORT-11718
Update API minor version from 70 to 75. Lower versions will be depricated. No changes between downloaded endpoints in both versions of API.